### PR TITLE
fix SPIFFS_USE_MAGIC + fix Windows compile with -mno-ms-bitfields

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ ifeq ($(OS),Windows_NT)
 	ARCHIVE_CMD := 7z a
 	ARCHIVE_EXTENSION := zip
 	TARGET := mkspiffs.exe
+	TARGET_CFLAGS := -mno-ms-bitfields
 	TARGET_LDFLAGS := -Wl,-static -static-libgcc
 
 else

--- a/spiffs/spiffs_config.h
+++ b/spiffs/spiffs_config.h
@@ -136,7 +136,7 @@ typedef uint8_t u8_t;
 // not on mount point. If not, SPIFFS_format must be called prior to mounting
 // again.
 #ifndef SPIFFS_USE_MAGIC
-#define SPIFFS_USE_MAGIC                (0)
+#define SPIFFS_USE_MAGIC                (1)
 #endif
 
 // SPIFFS_LOCK and SPIFFS_UNLOCK protects spiffs from reentrancy on api level


### PR DESCRIPTION
fix SPIFFS_USE_MAGIC + fix Windows compile with -mno-ms-bitfields