### PR TITLE
Fix unpackFiles bug

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -365,7 +365,7 @@ bool unpackFiles(std::string sDest) {
             size_t pos = name.find_last_of("/");
 
             // If file is in sub directory?
-            if (pos > 0) {
+            if (pos != std::string::npos) {
                 // Subdir path.
                 std::string path = sDest;
                 path += name.substr(0, pos);


### PR DESCRIPTION
pos is of size_t, which can be (and almost always is) unsigned (mingw-32 for example); so (pos > 0) is always true even if name does not contain '/'
as a result, unpackFiles always creates empty dirs instead of write to file(s)
