### PR TITLE
Check for current dir more explicitly

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -175,9 +175,11 @@ int addFiles(const char* dirname, const char* subPath) {
 
         // Read files from directory.
         while ((ent = readdir (dir)) != NULL) {
+
             // Ignore dir itself.
-            if (ent->d_name[0] == '.')
+            if ((strcmp(ent->d_name, ".") == 0) || (strcmp(ent->d_name, "..") == 0)) {
                 continue;
+            }
 
             std::string fullpath = dirPath;
             fullpath += ent->d_name;


### PR DESCRIPTION
This is a nice-to-have.
Checking for current dir more explicitly will allow to add dot-starting files to the image. In the linux world these use to have settings and alike, so they can be used to store configuration in SPIFFS (like SPIFFS image version, for instance). The common webserver setup can then ignore these by

```
server.onNotFound([]() {

  // Hidden files
  if (server.uri().startsWith("/.")) {
    server.send(403, "text/plain", "Forbidden");
    return;
  }

  // Existing files in SPIFFS
  if (!handleFileRead(server.uri())) {
    server.send(404, "text/plain", "NotFound");
    return;
  }

});
```
