### PR TITLE
SPIFFS: update to f5e26c4

### DIFF
--- a/spiffs/spiffs_hydrogen.c
+++ b/spiffs/spiffs_hydrogen.c
@@ -481,7 +481,6 @@ s32_t SPIFFS_write(spiffs *fs, spiffs_file fh, void *buf, s32_t len) {
   if ((fd->flags & SPIFFS_O_APPEND)) {
     fd->fdoffset = fd->size == SPIFFS_UNDEFINED_LEN ? 0 : fd->size;
   }
-
   offset = fd->fdoffset;
 
 #if SPIFFS_CACHE_WR

--- a/spiffs/spiffs_nucleus.c
+++ b/spiffs/spiffs_nucleus.c
@@ -1061,12 +1061,18 @@ void spiffs_cb_object_event(
 #if SPIFFS_TEMPORAL_FD_CACHE
         if (cur_fd->score == 0) continue; // never used fd
 #endif
-        SPIFFS_DBG("       callback: setting fd "_SPIPRIfd":"_SPIPRIid"(fdoffs:"_SPIPRIi" offs:"_SPIPRIi") objix_hdr_pix to "_SPIPRIpg", size:"_SPIPRIi"\n", SPIFFS_FH_OFFS(fs, cur_fd->file_nbr), cur_fd->obj_id, cur_fd->fdoffset, cur_fd->offset, new_pix, new_size);
+        SPIFFS_DBG("       callback: setting fd "_SPIPRIfd":"_SPIPRIid"(fdoffs:"_SPIPRIi" offs:"_SPIPRIi") objix_hdr_pix to "_SPIPRIpg", size:"_SPIPRIi"\n",
+            SPIFFS_FH_OFFS(fs, cur_fd->file_nbr), cur_fd->obj_id, cur_fd->fdoffset, cur_fd->offset, new_pix, new_size);
         cur_fd->objix_hdr_pix = new_pix;
         if (new_size != 0) {
           // update size and offsets for fds to this file
           cur_fd->size = new_size;
           u32_t act_new_size = new_size == SPIFFS_UNDEFINED_LEN ? 0 : new_size;
+#if SPIFFS_CACHE_WR
+          if (act_new_size > 0 && cur_fd->cache_page) {
+            act_new_size = MAX(act_new_size, cur_fd->cache_page->offset + cur_fd->cache_page->size);
+          }
+#endif
           if (cur_fd->offset > act_new_size) {
             cur_fd->offset = act_new_size;
           }

--- a/spiffs/spiffs_nucleus.h
+++ b/spiffs/spiffs_nucleus.h
@@ -141,6 +141,22 @@
 #define SPIFFS_OBJ_ID_DELETED           ((spiffs_obj_id)0)
 #define SPIFFS_OBJ_ID_FREE              ((spiffs_obj_id)-1)
 
+
+
+#if defined(__GNUC__) || defined(__clang__)
+    /* For GCC and clang */
+#define SPIFFS_PACKED __attribute__((packed))
+#elif defined(__ICCARM__) || defined(__CC_ARM)
+    /* For IAR ARM and Keil MDK-ARM compilers */
+#define SPIFFS_PACKED 
+
+#else
+    /* Unknown compiler */
+#define SPIFFS_PACKED 
+#endif
+
+
+
 #if SPIFFS_USE_MAGIC
 #if !SPIFFS_USE_MAGIC_LENGTH
 #define SPIFFS_MAGIC(fs, bix)           \
@@ -464,7 +480,7 @@ typedef struct {
 // page header, part of each page except object lookup pages
 // NB: this is always aligned when the data page is an object index,
 // as in this case struct spiffs_page_object_ix is used
-typedef struct __attribute(( packed )) {
+typedef struct SPIFFS_PACKED {
   // object id
   spiffs_obj_id obj_id;
   // object span index
@@ -474,7 +490,7 @@ typedef struct __attribute(( packed )) {
 } spiffs_page_header;
 
 // object index header page header
-typedef struct __attribute(( packed ))
+typedef struct SPIFFS_PACKED
 #if SPIFFS_ALIGNED_OBJECT_INDEX_TABLES
                 __attribute(( aligned(sizeof(spiffs_page_ix)) ))
 #endif
@@ -496,7 +512,7 @@ typedef struct __attribute(( packed ))
 } spiffs_page_object_ix_header;
 
 // object index page header
-typedef struct __attribute(( packed )) {
+typedef struct SPIFFS_PACKED {
  spiffs_page_header p_hdr;
  u8_t _align[4 - ((sizeof(spiffs_page_header)&3)==0 ? 4 : (sizeof(spiffs_page_header)&3))];
 } spiffs_page_object_ix;


### PR DESCRIPTION
This fix was released after the new release 0.1.3
all files over 25k was corrupted in the image file produced by the `mkspiffs` tool
further info in this issue  https://github.com/pellepl/spiffs/issues/165 and the commit https://github.com/pellepl/spiffs/commit/f5e26c4e933189593a71c6b82cda381a7b21e41c

and it's related to this issue https://github.com/esp8266/Arduino/issues/3612