### PR TITLE
Fix issue #26 , and maintain compatibility with SPIFFS v0.3.3

### DIFF
--- a/spiffs/spiffs_config.h
+++ b/spiffs/spiffs_config.h
@@ -199,7 +199,7 @@ typedef uint8_t u8_t;
 // be accepted for mounting with a configuration defining the filesystem as 2
 // megabytes.
 #ifndef SPIFFS_USE_MAGIC_LENGTH
-#define SPIFFS_USE_MAGIC_LENGTH         (1)
+#define SPIFFS_USE_MAGIC_LENGTH         (0)
 #endif
 #endif
 


### PR DESCRIPTION
This will maintain backward compatibility with SPIFFS v0.3.3 
but will disable the new security feature in the v0.3.7 ..

as (@igrr) suggested it can be turned back on in the next major release