### PR TITLE
Update build_all_configs.sh: Use CPPFLAGS instead of CFLAGS

### DIFF
--- a/build_all_configs.sh
+++ b/build_all_configs.sh
@@ -16,12 +16,12 @@ make dist BUILD_CONFIG_NAME="-arduino-esp8266" \
 # Build configuration for arduino-esp32
 make clean
 make dist BUILD_CONFIG_NAME="-arduino-esp32" \
-    CFLAGS="-DSPIFFS_OBJ_META_LEN=4"
+    CPPFLAGS="-DSPIFFS_OBJ_META_LEN=4"
 
 # Build configuration for ESP-IDF (esp32)
 make clean
 make dist BUILD_CONFIG_NAME="-esp-idf" \
-    CFLAGS="-DSPIFFS_OBJ_META_LEN=4"
+    CPPFLAGS="-DSPIFFS_OBJ_META_LEN=4"
 
 
 


### PR DESCRIPTION
`SPIFFS_OBJ_META_LEN` was not properly set for all languages (only for c).
See output of `mkspiffs --version`.