### PR TITLE
Add support for excluding files when building images

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,12 @@ Tool to build and unpack [SPIFFS](https://github.com/pellepl/spiffs) images.
 ## Usage
 
 ```
+   mkspiffs.exe  {-c <pack_dir>|-u <dest_dir>|-l|-i} [-d <0-5>] [-x
+                 <file_list>] ...  [-a] [-b <number>] [-p <number>] [-s
+                 <number>] [--] [--version] [-h] <image_file>
 
-   mkspiffs  {-c <pack_dir>|-u <dest_dir>|-l|-i} [-d <0-5>] [-b <number>]
-             [-p <number>] [-s <number>] [--] [--version] [-h]
-             <image_file>
 
-
-Where: 
+Where:
 
    -c <pack_dir>,  --create <pack_dir>
      (OR required)  create spiffs image from a directory
@@ -28,6 +27,13 @@ Where:
 
    -d <0-5>,  --debug <0-5>
      Debug level. 0 means no debug output.
+
+   -x <file_list>,  --exclude-files <file_list>  (accepted multiple times)
+     when creating an image, exclude these files (patterns accepted).
+
+   -a,  --all-files
+     when creating an image, include files which are normally ignored;
+     currently only applies to '.DS_Store' files and '.git' directories
 
    -b <number>,  --block <number>
      fs block size, in bytes

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ Tool to build and unpack [SPIFFS](https://github.com/pellepl/spiffs) images.
 ## Usage
 
 ```
-   mkspiffs.exe  {-c <pack_dir>|-u <dest_dir>|-l|-i} [-d <0-5>] [-x
-                 <file_list>] ...  [-a] [-b <number>] [-p <number>] [-s
-                 <number>] [--] [--version] [-h] <image_file>
+   mkspiffs  {-c <pack_dir>|-u <dest_dir>|-l|-i} [-d <0-5>] 
+             [-x <file_list>] ...  [-a] [-b <number>] [-p <number>] 
+             [-s <number>] [--] [--version] [-h] <image_file>
 
 
 Where:
@@ -55,7 +55,6 @@ Where:
 
    <image_file>
      (required)  spiffs image file
-
 
 ```
 ## Build


### PR DESCRIPTION
Hi everyone,

I've put together a change to allow for the exclusion of files duging the creation of SPIFFS images. I wondering if people would find it useful. 

My main concern with this change is the introduction of a dependency on the `fnmatch` function. For MinGW, I found an implementation in libiberty.a (I couldn't find a declaration in any of the header files I have though so I added one manually). However, I don't have easy access to other platforms, so assuming this change is desirable, I'd need help figuring out that dependency on other platforms as well. Due to this, I'm marking this PR as a draft for now.

Let me know what you think.

Thanks.