### PR TITLE
Add arm64 to build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,10 @@ matrix:
       - CROSS_TRIPLE=arm-linux-gnueabihf
       - EXTRA_ARGS='-e SKIP_TESTS=1'
     - env:
+      - TARGET_OS=linux-arm64
+      - CROSS_TRIPLE=aarch64-linux-gnu
+      - EXTRA_ARGS='-e SKIP_TESTS=1'
+    - env:
       - TARGET_OS=win32
       - CROSS_TRIPLE=i686-w64-mingw32
       # multiarch/crossbuild doesn't come with 'zip',


### PR DESCRIPTION
Arm64 job has been added, following armhf directives.

It would be great if you can create a new release (0.2.3.1) so I can use it in [espressif/arduino-esp32](https://github.com/espressif/arduino-esp32).