### PR TITLE
Allow specifying alternate spiffs_config.h location

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,12 @@ OBJ		:= main.o \
 
 INCLUDES := -Itclap -Iinclude -Ispiffs/src -I.
 
+ifneq ($(SPIFFS_CONFIG_H_DIR),)
+override INCLUDES :=  \
+	-I$(SPIFFS_CONFIG_H_DIR) \
+	$(INCLUDES)
+endif
+
 FILES_TO_FORMAT := $(shell find . -not -path './spiffs/*' \( -name '*.c' -o -name '*.cpp' \))
 
 DIFF_FILES := $(addsuffix .diff,$(FILES_TO_FORMAT))

--- a/README.md
+++ b/README.md
@@ -88,6 +88,13 @@ $ make clean
 $ make dist CPPFLAGS="-DSPIFFS_OBJ_META_LEN=4" BUILD_CONFIG_NAME=-custom
 ```
 
+To use an entire alternate SPIFFS configuration file, specify its location in `SPIFFS_CONFIG_H_DIR`:
+
+```bash
+$ make clean
+$ make dist SPIFFS_CONFIG_H_DIR=your/include/path
+```
+
 To check which options were set when building mkspiffs, use `--version` command:
 
 ```


### PR DESCRIPTION
When you already have a `spiffs_config.h` in your project, it's more convenient to have mkspiffs use it than copying all your customizations into the build command. Typedefs can't even be changed that way, so this option is more flexible.