### PR TITLE
Remove unsupported architecture from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,9 +37,9 @@ else
 endif
 
 ifeq ($(TARGET_OS),osx)
-	TARGET_CFLAGS   = -mmacosx-version-min=10.7 -arch i386 -arch x86_64
-	TARGET_CXXFLAGS = -mmacosx-version-min=10.7 -arch i386 -arch x86_64 -stdlib=libc++
-	TARGET_LDFLAGS  = -mmacosx-version-min=10.7 -arch i386 -arch x86_64 -stdlib=libc++
+	TARGET_CFLAGS   = -mmacosx-version-min=10.7 -arch x86_64
+	TARGET_CXXFLAGS = -mmacosx-version-min=10.7 -arch x86_64 -stdlib=libc++
+	TARGET_LDFLAGS  = -mmacosx-version-min=10.7 -arch x86_64 -stdlib=libc++
 endif
 
 # Packaging into archive (for 'dist' target)


### PR DESCRIPTION
Apple has removed support for outdated arch

It fixes this issue https://github.com/igrr/mkspiffs/issues/84